### PR TITLE
Mudança de ordem e atualização CACo

### DIFF
--- a/alem_da_graduacao/caco.tex
+++ b/alem_da_graduacao/caco.tex
@@ -202,43 +202,37 @@ CACo no Google Groups por meio do link:
     \includegraphics[width=.45\textwidth]{img/alem_da_graduacao/caco_eleicao.jpg}
 \end{figure}
 
-\subsubsection*{Chapa ``Agora é só esperar'' (2013/2014)}
+\subsubsection*{Chapa ``De Maior'' (2014/2015)}
 
 \begin{itemize}
     \item   \textbf{Presidência}
-        \\Pedro Emílio Machado de Brito (Asmina EC012)
+        \\Lauro Cruz e Souza (Peta EC014)
 
     \item   \textbf{Coordenadoria Administrativa}
-        \\Gabriel Hidasy Rezende (Sam CC011)
-        \\Gustavo de Mello Crivelli (Jobs EC012)
+        \\Guilherme Lucas da Silva (Virose EC014)
+        \\Henrique Noronha Facioli (Henrique EC014)
 
     \item   \textbf{Coodenadoria Financeira}
-        \\Julia Ramos Beltrão (EC011)
-        \\Gabriel Militão Vinhas Lopes (Gagau EC012)
+        \\Pedro Emílio Machado de Brito (Asmina EC012)
+        \\Pedro Rodrigues Grijó (Grijó EC012)
 
     \item   \textbf{Coordenadoria de Ensino e Graduação}
-        \\Alexandre Novais de Medeiros (Salsicha CC011)
-        \\Victor Fernando Pompêo Barbosa (Pompêo EC09)
-        \\Pedro Henrique Azevedo Amorim (Amora EC011)
+        \\Gabriel Militão Vinhas Lopes (Gagau EC012)
 
     \item   \textbf{Coordenadoria de Ensino e Pós-Graduação}
-        \\Eric Velten de Melo (EC07 / MSc012)
+    	\\ 
 
     \item   \textbf{Coordenadoria de Comunicação e Marketing}
-        \\Yuri Corrêa Pinto Soares (CC012)
-
+        \\Yuri Corrêa Pinto Soares (Yuri CC012)
+        
     \item   \textbf{Coordenadoria de Eventos e Cultura}
-        \\Antonio José Pinheiro Prado (Alegria EC012)
-        \\Luís Felipe Hamada Serrano (Yudi EC013)
+        \\Isadora Sophia Garcia Rodopoulos (Isadora EC014)
 
     \item   \textbf{Coordenadoria de Produtos}
-        \\Henrique Lacreta Alves (Perônio EC012)
-        \\João Pedro Ramos Lopes (Barney EC012)
+        \\Alex Wei (Boquinha EC014)
 
     \item    \textbf{Coordenadoria Tecnológica}
-        \\Edson Duarte da Silva Junior (EC013)
-        \\Francesco Perrotti-Garcia (EC012)
-        \\Mateus Muniz Vitor (EC013)
+        \\Lucas Silva Schanner (Capivas EC014)
 \end{itemize}
 
 As gestões dos anos anteriores podem ser vistas no site do CACo.

--- a/alem_da_graduacao/grupos_entidades.tex
+++ b/alem_da_graduacao/grupos_entidades.tex
@@ -89,6 +89,22 @@ Microsoft e Facebook.
 Para participar dos treinamentos para a Maratona que acontecem na Unicamp,
 visite a wiki \url{www.ic.unicamp.br/~maratona/wiki}.
 
+\subsection{Gamux}
+
+O Gamux (Grupo de Pesquisa e Desenvolvimento de Jogos da Unicamp), composto por
+computeiros e alunos do IA (Instituto de Artes), é uma ótima oportunidade para
+quem tiver curiosidade de saber como são feitos os jogos eletrônicos.
+
+Fique atento, eles costumam organizar ciclos de palestras e eventos relacionados
+a desenvolvimento de jogos.
+
+Mas não precisa esperar até lá! Entre no grupo de e-mail:
+
+\begin{compactitemize}
+    \item  Site: \url{gamux.com.br}
+    \item  Lista de discussão: \url{groups.google.com/}\\\url{group/gamedev_unicamp}
+\end{compactitemize}
+
 \subsection{DCE}
 
 Criado em 1978, o DCE Unicamp (Diretório Central dos Estudantes) é a entidade
@@ -153,23 +169,6 @@ inscrições através do site. Se envolva!
 \begin{compactitemize}
     \item  Site: \url{phoenixunicamp.com.br}
     \item  Facebook: \url{fb.com/phoenixunicamp}
-\end{compactitemize}
-
-\subsection{Gamux}
-
-O Gamux (Grupo de Pesquisa e Desenvolvimento de Jogos da Unicamp), composto por
-computeiros e alunos do IA (Instituto de Artes), é uma ótima oportunidade para
-quem tiver curiosidade de saber como são feitos os jogos eletrônicos.
-
-Fique atento, eles costumam organizar ciclos de palestras e eventos relacionados
-a desenvolvimento de jogos.
-
-Mas não precisa esperar até lá! Apareça no LMS (Laboratório da Microsoft,
-próximo as mesinhas do IC3) ou entre no grupo de e-mail.
-
-\begin{compactitemize}
-    \item  Site: \url{gamux.com.br}
-    \item  Lista de discussão: \url{groups.google.com/}\\\url{group/gamedev_unicamp}
 \end{compactitemize}
 
 \subsection{GPSL}

--- a/manual_do_bixo.tex
+++ b/manual_do_bixo.tex
@@ -199,17 +199,17 @@ Aproveite!
 \input{unicamp/melhores_banheiros.tex}
 
 \chapter{Além da graduação}
+%%%%% Centro Acadêmico da Computação
+\input{alem_da_graduacao/caco.tex}
+\newpage
+%%%%% Atlética -- AAACEC
+\input{alem_da_graduacao/aaacec.tex}
+\newpage
 %%%%% Grupos e Entidades da Unicamp
 \input{alem_da_graduacao/grupos_entidades.tex}
 \newpage
 %%%%% Conpec
 \input{alem_da_graduacao/conpec.tex}
-\newpage
-%%%%% Atlética -- AAACEC
-\input{alem_da_graduacao/aaacec.tex}
-\newpage
-%%%%% Centro Acadêmico da Computação
-\input{alem_da_graduacao/caco.tex}
 \newpage
 %%%%% Eventos da Unicamp
 \input{alem_da_graduacao/eventos.tex}


### PR DESCRIPTION
-Mudança de ordem:  
   CACo como primeira entidade alem da graduação
   AAACEC como segunda. (Eles colocaram o CACo no desenho do kit bixo <3)
   Gamux subiu na ordem.
Modificação da Chapa para "De Maior"
